### PR TITLE
feat(companion): add debug ProfileStore seeding for IPC integration testing

### DIFF
--- a/companion/src/main/kotlin/dev/gwaboard/companion/CompanionApplication.kt
+++ b/companion/src/main/kotlin/dev/gwaboard/companion/CompanionApplication.kt
@@ -2,6 +2,8 @@ package dev.gwaboard.companion
 
 import android.app.Application
 import android.util.Log
+import dev.gwaboard.companion.provider.ProfileStore
+import dev.gwaboard.shared.models.ContactProfile
 
 /**
  * Application class for the companion SMS app.
@@ -13,11 +15,55 @@ class CompanionApplication : Application() {
 
     companion object {
         private const val TAG = "CompanionApp"
+
+        /**
+         * Shared ProfileStore instance accessible to both the Application
+         * (for debug seeding) and the SmsContentProvider.
+         *
+         * This will be replaced by Koin DI once services are implemented.
+         */
+        val profileStore = ProfileStore()
     }
 
     override fun onCreate() {
         super.onCreate()
         Log.i(TAG, "GwaBoard Companion application created")
+
+        if (BuildConfig.DEBUG) {
+            seedDebugProfiles()
+        }
+
         // TODO: Initialize Koin DI modules once services are implemented
+    }
+
+    /**
+     * Seeds the ProfileStore with sample data for IPC integration testing.
+     *
+     * Only runs in debug builds. Provides known test data so that
+     * instrumented tests can validate the full IPC pipeline:
+     * keyboard → ContentResolver → SmsContentProvider → ProfileStore → data.
+     */
+    private fun seedDebugProfiles() {
+        profileStore.putProfile(
+            1L,
+            ContactProfile(
+                dominantLanguage = "fr",
+                tone = "casual",
+                avgResponseLength = 42,
+                topNgrams = listOf("salut", "ok", "merci"),
+                styleEmbedding = listOf(0.1f, 0.2f, 0.3f),
+            ),
+        )
+        profileStore.putProfile(
+            2L,
+            ContactProfile(
+                dominantLanguage = "en",
+                tone = "formal",
+                avgResponseLength = 120,
+                topNgrams = listOf("hello", "regards", "please"),
+                styleEmbedding = listOf(0.4f, 0.5f, 0.6f),
+            ),
+        )
+        Log.i(TAG, "Debug profiles seeded: ${profileStore.size} entries")
     }
 }

--- a/companion/src/main/kotlin/dev/gwaboard/companion/provider/SmsContentProvider.kt
+++ b/companion/src/main/kotlin/dev/gwaboard/companion/provider/SmsContentProvider.kt
@@ -9,9 +9,12 @@ import android.net.Uri
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
+import dev.gwaboard.companion.BuildConfig
+import dev.gwaboard.companion.CompanionApplication
 import dev.gwaboard.shared.crypto.EncryptedPayload
 import dev.gwaboard.shared.crypto.SessionCipher
 import dev.gwaboard.shared.ipc.SignatureVerifier
+import dev.gwaboard.shared.models.ContactProfile
 import dev.gwaboard.shared.models.IpcContract
 
 /**
@@ -65,15 +68,64 @@ class SmsContentProvider : ContentProvider() {
     private lateinit var sessionCipher: SessionCipher
 
     /**
-     * In-memory profile store. In a real implementation, this would be backed
-     * by a Room database or similar persistent storage populated by the
-     * companion app's SMS analysis pipeline.
+     * Shared profile store, initialized by [CompanionApplication].
+     *
+     * In a real implementation, this would be backed by a Room database
+     * populated by the companion app's SMS analysis pipeline.
+     * For now, the Application seeds it with debug data on startup.
      */
-    private val profileStore = ProfileStore()
+    private val profileStore: ProfileStore
+        get() = CompanionApplication.profileStore
 
     override fun onCreate(): Boolean {
         sessionCipher = SessionCipher()
         return true
+    }
+
+    /**
+     * Debug-only endpoint for seeding test data from the keyboard's
+     * instrumented tests via `ContentResolver.call()`.
+     *
+     * Supported methods:
+     * - `seed_test_data`: Inserts a known test profile (contactId=1).
+     *   Returns a Bundle with `"success" = true` on success.
+     * - `clear_test_data`: Removes all profiles from the store.
+     *   Returns a Bundle with `"success" = true` on success.
+     *
+     * Returns `null` in release builds — this endpoint is disabled entirely.
+     */
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        if (!BuildConfig.DEBUG) return null
+
+        return when (method) {
+            "seed_test_data" -> {
+                profileStore.putProfile(
+                    1L,
+                    ContactProfile(
+                        dominantLanguage = "fr",
+                        tone = "casual",
+                        avgResponseLength = 42,
+                        topNgrams = listOf("salut", "ok", "merci"),
+                        styleEmbedding = listOf(0.1f, 0.2f, 0.3f),
+                    ),
+                )
+                Log.i(TAG, "Debug: test data seeded via call()")
+                Bundle().apply { putBoolean("success", true) }
+            }
+
+            "clear_test_data" -> {
+                // Clear all profiles by removing known test IDs
+                profileStore.removeProfile(1L)
+                profileStore.removeProfile(2L)
+                Log.i(TAG, "Debug: test data cleared via call()")
+                Bundle().apply { putBoolean("success", true) }
+            }
+
+            else -> {
+                Log.w(TAG, "Unknown call method: $method")
+                null
+            }
+        }
     }
 
     override fun query(

--- a/keyboard/src/androidTest/kotlin/dev/gwaboard/keyboard/ipc/IpcCommunicationTest.kt
+++ b/keyboard/src/androidTest/kotlin/dev/gwaboard/keyboard/ipc/IpcCommunicationTest.kt
@@ -2,6 +2,7 @@ package dev.gwaboard.keyboard.ipc
 
 import android.content.ContentResolver
 import android.net.Uri
+import android.os.Bundle
 import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -9,6 +10,7 @@ import dev.gwaboard.shared.ipc.SignatureVerifier
 import dev.gwaboard.shared.ipc.SmsProviderClient
 import dev.gwaboard.shared.ipc.SmsProviderContract
 import dev.gwaboard.shared.models.IpcContract
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -240,5 +242,153 @@ class IpcCommunicationTest {
             "Contacts query should return empty list (URI not handled)",
             contacts.isEmpty(),
         )
+    }
+
+    // ── Layer 5: Debug Seeding via call() ──────────────────────────────
+
+    @Test
+    fun contentProvider_callSeedTestData_returnsSuccess() {
+        // Seed test data via the debug call() endpoint
+        val result = contentResolver.call(
+            Uri.parse(IpcContract.BASE_URI),
+            "seed_test_data",
+            null,
+            null,
+        )
+
+        assertNotNull("seed_test_data should return a non-null Bundle", result)
+        assertTrue(
+            "seed_test_data should return success=true",
+            result!!.getBoolean("success", false),
+        )
+    }
+
+    @Test
+    fun contentProvider_callClearTestData_returnsSuccess() {
+        // Clear test data via the debug call() endpoint
+        val result = contentResolver.call(
+            Uri.parse(IpcContract.BASE_URI),
+            "clear_test_data",
+            null,
+            null,
+        )
+
+        assertNotNull("clear_test_data should return a non-null Bundle", result)
+        assertTrue(
+            "clear_test_data should return success=true",
+            result!!.getBoolean("success", false),
+        )
+    }
+
+    // ── Layer 6: Seeded Data Verification ──────────────────────────────
+
+    @Test
+    fun contentProvider_afterSeeding_returnsNonEmptyCursor() {
+        // Seed first via call()
+        contentResolver.call(
+            Uri.parse(IpcContract.BASE_URI),
+            "seed_test_data",
+            null,
+            null,
+        )
+
+        // Query all profiles — should now have at least one row
+        val cursor = contentResolver.query(
+            SmsProviderContract.CONTACT_PROFILES_URI,
+            null, null, null, null,
+        )
+
+        assertNotNull("Cursor should not be null after seeding", cursor)
+        cursor!!.use { c ->
+            Log.i(TAG, "After seeding: cursor has ${c.count} rows")
+            assertTrue(
+                "Cursor should contain at least 1 row after seeding",
+                c.count > 0,
+            )
+        }
+    }
+
+    @Test
+    fun contentProvider_afterSeeding_singleProfileHasEncryptedData() {
+        // Seed via call()
+        contentResolver.call(
+            Uri.parse(IpcContract.BASE_URI),
+            "seed_test_data",
+            null,
+            null,
+        )
+
+        // Query the specific seeded profile (contactId=1)
+        val uri = Uri.withAppendedPath(
+            SmsProviderContract.CONTACT_PROFILES_URI,
+            "1",
+        )
+        val cursor = contentResolver.query(uri, null, null, null, null)
+
+        assertNotNull("Single profile cursor should not be null", cursor)
+        cursor!!.use { c ->
+            assertEquals(
+                "Seeded profile for contactId=1 should return exactly 1 row",
+                1,
+                c.count,
+            )
+
+            assertTrue("Cursor should move to first row", c.moveToFirst())
+
+            // Verify encrypted columns are present and non-empty
+            val encryptedData = c.getString(
+                c.getColumnIndexOrThrow("encrypted_data"),
+            )
+            val encryptedIv = c.getString(
+                c.getColumnIndexOrThrow("encrypted_iv"),
+            )
+
+            assertNotNull("encrypted_data should not be null", encryptedData)
+            assertNotNull("encrypted_iv should not be null", encryptedIv)
+            assertTrue(
+                "encrypted_data should be non-empty Base64",
+                encryptedData.isNotEmpty(),
+            )
+            assertTrue(
+                "encrypted_iv should be non-empty Base64",
+                encryptedIv.isNotEmpty(),
+            )
+
+            Log.i(TAG, "Seeded profile encrypted_data length: ${encryptedData.length}")
+            Log.i(TAG, "Seeded profile encrypted_iv length: ${encryptedIv.length}")
+        }
+    }
+
+    @Test
+    fun contentProvider_afterClear_returnsEmptyCursor() {
+        // Seed then clear
+        contentResolver.call(
+            Uri.parse(IpcContract.BASE_URI),
+            "seed_test_data",
+            null,
+            null,
+        )
+        contentResolver.call(
+            Uri.parse(IpcContract.BASE_URI),
+            "clear_test_data",
+            null,
+            null,
+        )
+
+        // Query the cleared profile — should be empty
+        val uri = Uri.withAppendedPath(
+            SmsProviderContract.CONTACT_PROFILES_URI,
+            "1",
+        )
+        val cursor = contentResolver.query(uri, null, null, null, null)
+
+        assertNotNull("Cursor should not be null after clear", cursor)
+        cursor!!.use { c ->
+            assertEquals(
+                "Cursor should be empty after clearing test data",
+                0,
+                c.count,
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add debug-only seeding in `CompanionApplication.onCreate()` that populates the `ProfileStore` with two sample `ContactProfile` entries (French casual + English formal)
- Add `ContentProvider.call()` debug endpoint in `SmsContentProvider` with `seed_test_data` and `clear_test_data` methods for runtime test data injection from the keyboard's instrumented tests
- Add 5 new instrumented tests in `IpcCommunicationTest` that validate the full IPC pipeline: seeding, non-empty cursor after seeding, encrypted payload presence, and cleanup after clearing

## Test plan

- [ ] Verify `CompanionApplication` seeds 2 profiles on debug startup
- [ ] Verify `SmsContentProvider.call("seed_test_data")` returns `success=true`
- [ ] Verify `SmsContentProvider.call("clear_test_data")` returns `success=true`
- [ ] Verify cursor is non-empty after seeding via `call()`
- [ ] Verify encrypted columns contain non-empty Base64 data for seeded profile
- [ ] Verify cursor is empty after clearing test data
- [ ] Verify `call()` returns `null` in release builds (no debug endpoint exposed)

Closes #52