### PR TITLE
fix(general): bug: Android Keystore AES-256 key not shareable between...

### DIFF
--- a/companion/src/main/kotlin/dev/gwaboard/companion/provider/ProfileStore.kt
+++ b/companion/src/main/kotlin/dev/gwaboard/companion/provider/ProfileStore.kt
@@ -33,6 +33,25 @@ class ProfileStore {
     }
 
     /**
+     * Retrieve the [ContactProfile] for a specific contact.
+     *
+     * @param contactId System contact identifier
+     * @return The [ContactProfile], or `null` if no profile exists
+     */
+    fun getProfileObject(contactId: Long): ContactProfile? {
+        return profiles[contactId]
+    }
+
+    /**
+     * Retrieve all stored profiles as (contactId, [ContactProfile]) pairs.
+     *
+     * @return Map of contact IDs to their [ContactProfile] instances
+     */
+    fun getAllProfileObjects(): Map<Long, ContactProfile> {
+        return profiles.toMap()
+    }
+
+    /**
      * Retrieve the profile JSON for a specific contact.
      *
      * @param contactId System contact identifier

--- a/companion/src/main/kotlin/dev/gwaboard/companion/provider/SmsContentProvider.kt
+++ b/companion/src/main/kotlin/dev/gwaboard/companion/provider/SmsContentProvider.kt
@@ -6,11 +6,7 @@ import android.content.UriMatcher
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
-import android.os.Bundle
-import android.util.Base64
 import android.util.Log
-import dev.gwaboard.shared.crypto.EncryptedPayload
-import dev.gwaboard.shared.crypto.SessionCipher
 import dev.gwaboard.shared.ipc.SignatureVerifier
 import dev.gwaboard.shared.models.IpcContract
 
@@ -29,9 +25,11 @@ import dev.gwaboard.shared.models.IpcContract
  *    verification using [SignatureVerifier], guarding against edge cases where
  *    permission grants could be spoofed.
  *
- * 3. **Payload-level**: All query results are encrypted with AES-256-GCM via
- *    [SessionCipher] before being returned in the cursor. The keyboard app
- *    must decrypt using the same Keystore-backed key.
+ * Note: AES-256-GCM payload encryption was removed because Android Keystore keys
+ * are UID-bound — two apps with different UIDs cannot share the same key, causing
+ * AEADBadTagException on decryption. The two layers above (OS signature permission
+ * + runtime certificate verification) provide sufficient protection for local IPC.
+ * See issue #51 for the full threat model analysis.
  *
  * ## Supported URI patterns
  *
@@ -47,22 +45,26 @@ class SmsContentProvider : ContentProvider() {
         private const val PROFILES_ALL = 1
         private const val PROFILES_BY_CONTACT = 2
 
-        /** Column name for the encrypted payload (Base64-encoded ciphertext) */
-        const val COLUMN_ENCRYPTED_DATA = "encrypted_data"
+        /** Column name for the contact ID */
+        const val COLUMN_CONTACT_ID = IpcContract.ContactColumns.CONTACT_ID
 
-        /** Column name for the IV (Base64-encoded) needed to decrypt the payload */
-        const val COLUMN_ENCRYPTED_IV = "encrypted_iv"
-
-        /** Column name for the contact ID in encrypted result sets */
-        const val COLUMN_CONTACT_ID = "contact_id"
+        /**
+         * Cursor column names for profile query results, matching [IpcContract.ProfileColumns].
+         */
+        private val PROFILE_COLUMNS = arrayOf(
+            COLUMN_CONTACT_ID,
+            IpcContract.ProfileColumns.DOMINANT_LANGUAGE,
+            IpcContract.ProfileColumns.TONE,
+            IpcContract.ProfileColumns.AVG_RESPONSE_LENGTH,
+            IpcContract.ProfileColumns.TOP_NGRAMS,
+            IpcContract.ProfileColumns.STYLE_EMBEDDING,
+        )
 
         private val uriMatcher = UriMatcher(UriMatcher.NO_MATCH).apply {
             addURI(IpcContract.AUTHORITY, IpcContract.Paths.CONTACT_PROFILES, PROFILES_ALL)
             addURI(IpcContract.AUTHORITY, "${IpcContract.Paths.CONTACT_PROFILES}/#", PROFILES_BY_CONTACT)
         }
     }
-
-    private lateinit var sessionCipher: SessionCipher
 
     /**
      * In-memory profile store. In a real implementation, this would be backed
@@ -72,7 +74,6 @@ class SmsContentProvider : ContentProvider() {
     private val profileStore = ProfileStore()
 
     override fun onCreate(): Boolean {
-        sessionCipher = SessionCipher()
         return true
     }
 
@@ -108,25 +109,23 @@ class SmsContentProvider : ContentProvider() {
     // ── Query implementations ─────────────────────────────────────────
 
     /**
-     * Returns all available contact profiles, each row encrypted individually.
+     * Returns all available contact profiles as plaintext cursor rows.
      *
-     * Cursor columns:
-     * - [COLUMN_CONTACT_ID]: the contact ID (unencrypted, needed for routing)
-     * - [COLUMN_ENCRYPTED_DATA]: Base64-encoded AES-256-GCM ciphertext of the profile JSON
-     * - [COLUMN_ENCRYPTED_IV]: Base64-encoded IV for decryption
+     * Cursor columns match [IpcContract.ProfileColumns] so the keyboard's
+     * [SmsProviderClient] can read them directly without decryption.
      */
     private fun queryAllProfiles(): Cursor {
-        val cursor = MatrixCursor(
-            arrayOf(COLUMN_CONTACT_ID, COLUMN_ENCRYPTED_DATA, COLUMN_ENCRYPTED_IV),
-        )
+        val cursor = MatrixCursor(PROFILE_COLUMNS)
 
-        for ((contactId, profileJson) in profileStore.getAllProfiles()) {
-            val encrypted = sessionCipher.encrypt(profileJson.toByteArray(Charsets.UTF_8))
+        for ((contactId, profile) in profileStore.getAllProfileObjects()) {
             cursor.addRow(
                 arrayOf(
                     contactId,
-                    Base64.encodeToString(encrypted.ciphertext, Base64.NO_WRAP),
-                    Base64.encodeToString(encrypted.iv, Base64.NO_WRAP),
+                    profile.dominantLanguage,
+                    profile.tone,
+                    profile.avgResponseLength,
+                    profile.topNgrams.joinToString(","),
+                    profile.styleEmbedding.joinToString(","),
                 ),
             )
         }
@@ -135,24 +134,24 @@ class SmsContentProvider : ContentProvider() {
     }
 
     /**
-     * Returns a single contact profile, encrypted with AES-256-GCM.
+     * Returns a single contact profile as a plaintext cursor row.
      *
      * @param contactId System contact identifier
      * @return Cursor with one row if profile exists, empty cursor otherwise
      */
     private fun querySingleProfile(contactId: Long): Cursor {
-        val cursor = MatrixCursor(
-            arrayOf(COLUMN_CONTACT_ID, COLUMN_ENCRYPTED_DATA, COLUMN_ENCRYPTED_IV),
-        )
+        val cursor = MatrixCursor(PROFILE_COLUMNS)
 
-        val profileJson = profileStore.getProfile(contactId) ?: return cursor
+        val profile = profileStore.getProfileObject(contactId) ?: return cursor
 
-        val encrypted = sessionCipher.encrypt(profileJson.toByteArray(Charsets.UTF_8))
         cursor.addRow(
             arrayOf(
                 contactId,
-                Base64.encodeToString(encrypted.ciphertext, Base64.NO_WRAP),
-                Base64.encodeToString(encrypted.iv, Base64.NO_WRAP),
+                profile.dominantLanguage,
+                profile.tone,
+                profile.avgResponseLength,
+                profile.topNgrams.joinToString(","),
+                profile.styleEmbedding.joinToString(","),
             ),
         )
 

--- a/keyboard/src/androidTest/kotlin/dev/gwaboard/keyboard/ipc/IpcCommunicationTest.kt
+++ b/keyboard/src/androidTest/kotlin/dev/gwaboard/keyboard/ipc/IpcCommunicationTest.kt
@@ -134,9 +134,11 @@ class IpcCommunicationTest {
     // ── Layer 3: Column Schema Validation ────────────────────────────
 
     @Test
-    fun contentProvider_columns_matchExpectedSchema() {
-        // Diagnoses the column mismatch bug: SmsContentProvider returns
-        // encrypted columns, but SmsProviderClient expects plaintext columns.
+    fun contentProvider_columns_matchPlaintextSchema() {
+        // Validates that SmsContentProvider returns plaintext columns
+        // matching IpcContract.ProfileColumns, which SmsProviderClient
+        // reads directly. Encryption was removed because Android Keystore
+        // keys are UID-bound (see issue #51).
 
         val cursor = contentResolver.query(
             SmsProviderContract.CONTACT_PROFILES_URI,
@@ -146,11 +148,9 @@ class IpcCommunicationTest {
         cursor.use { c ->
             val actualColumns = c.columnNames.toSet()
 
-            // Columns returned by SmsContentProvider (encrypted schema)
-            val encryptedColumns = setOf("contact_id", "encrypted_data", "encrypted_iv")
-
             // Columns expected by SmsProviderClient (plaintext schema)
-            val plaintextColumns = setOf(
+            val expectedColumns = setOf(
+                IpcContract.ContactColumns.CONTACT_ID,
                 IpcContract.ProfileColumns.DOMINANT_LANGUAGE,
                 IpcContract.ProfileColumns.TONE,
                 IpcContract.ProfileColumns.AVG_RESPONSE_LENGTH,
@@ -158,29 +158,13 @@ class IpcCommunicationTest {
                 IpcContract.ProfileColumns.STYLE_EMBEDDING,
             )
 
-            Log.w(TAG, "=== COLUMN SCHEMA DIAGNOSTIC ===")
-            Log.w(TAG, "Actual columns from provider: $actualColumns")
-            Log.w(TAG, "Encrypted columns (provider sends): $encryptedColumns")
-            Log.w(TAG, "Plaintext columns (client expects): $plaintextColumns")
+            Log.i(TAG, "=== COLUMN SCHEMA VALIDATION ===")
+            Log.i(TAG, "Actual columns from provider: $actualColumns")
+            Log.i(TAG, "Expected plaintext columns: $expectedColumns")
 
-            val hasEncryptedSchema = actualColumns.containsAll(encryptedColumns)
-            val hasPlaintextSchema = actualColumns.containsAll(plaintextColumns)
-
-            if (hasEncryptedSchema && !hasPlaintextSchema) {
-                Log.e(
-                    TAG,
-                    "BUG CONFIRMED: Provider returns encrypted columns but " +
-                        "client expects plaintext columns. SmsProviderClient needs " +
-                        "a decryption layer.",
-                )
-            }
-
-            // This assertion documents the current (broken) state.
-            // When the bug is fixed, change this to assert plaintext or
-            // encrypted+decryption columns as appropriate.
             assertTrue(
-                "Provider should return encrypted columns (current schema)",
-                hasEncryptedSchema,
+                "Provider should return plaintext profile columns matching IpcContract.ProfileColumns",
+                actualColumns.containsAll(expectedColumns),
             )
         }
     }

--- a/shared-crypto/src/main/kotlin/dev/gwaboard/shared/crypto/KeystoreHelper.kt
+++ b/shared-crypto/src/main/kotlin/dev/gwaboard/shared/crypto/KeystoreHelper.kt
@@ -11,12 +11,18 @@ import javax.crypto.SecretKey
  *
  * Keys are hardware-backed on supported devices (Tensor G3 on Pixel 8A)
  * and tied to the calling app's UID — no other app can access them.
+ *
+ * **Important**: Because Keystore keys are UID-bound, they cannot be shared
+ * between the keyboard and companion apps (different UIDs). Two apps using
+ * the same alias will each get a distinct key, causing AEADBadTagException
+ * on cross-app decryption. Use this helper only for app-local encryption
+ * (e.g., local data-at-rest protection), not for IPC payload encryption.
  */
 object KeystoreHelper {
 
     private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
 
-    /** Default alias for the IPC encryption key shared between keyboard and companion */
+    /** Default alias for the app-local AES-256 encryption key (e.g., data-at-rest) */
     const val IPC_KEY_ALIAS = "gwaboard_ipc_aes256"
 
     /**

--- a/shared-crypto/src/main/kotlin/dev/gwaboard/shared/crypto/SessionCipher.kt
+++ b/shared-crypto/src/main/kotlin/dev/gwaboard/shared/crypto/SessionCipher.kt
@@ -5,11 +5,19 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 
 /**
- * AES-256-GCM encrypt/decrypt operations for IPC payload protection.
+ * AES-256-GCM encrypt/decrypt operations for local data-at-rest protection.
  *
  * Each encryption generates a fresh 12-byte IV (never reused).
  * The GCM authentication tag (128-bit) is appended to the ciphertext
  * by the Android Cipher implementation.
+ *
+ * **Note**: This cipher is intended for app-local encryption only (e.g.,
+ * caching sensitive data on disk). It must NOT be used for cross-app IPC
+ * because Android Keystore keys are UID-bound — two apps with different
+ * UIDs will each generate distinct keys under the same alias, causing
+ * AEADBadTagException on decryption. IPC between keyboard and companion
+ * is protected by signature-level permissions and runtime certificate
+ * verification instead.
  *
  * Usage:
  * ```


### PR DESCRIPTION
## Summary
Implements #51



## Modules impactes


## Changes
```
 .pipeline/context.json                             | 19 +++---
 .pipeline/diff-cache.txt                           |  6 ++
 .../gwaboard/companion/provider/ProfileStore.kt    | 19 ++++++
 .../companion/provider/SmsContentProvider.kt       | 75 +++++++++++-----------
 .../gwaboard/keyboard/ipc/IpcCommunicationTest.kt  | 40 ++++--------
 .../dev/gwaboard/shared/crypto/KeystoreHelper.kt   |  8 ++-
 .../dev/gwaboard/shared/crypto/SessionCipher.kt    | 10 ++-
 7 files changed, 100 insertions(+), 77 deletions(-)
```

## Criteres d'acceptation
N/A

## Test Plan
- [ ] Tests unitaires passent
- [ ] Detekt clean


Closes #51